### PR TITLE
Use list type for pointing

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ MatsScheduleStack(
     app,
     "MatsScheduleToParquetStack",
     input_bucket_name="ops-mats-schedule-source-v0.1",
-    output_bucket_name="ops-mats-schedule-v0.1",
+    output_bucket_name="ops-mats-schedule-v0.2",
     queue_arn_export_name="L0ScheduleFetcherStackOutputQueue",
 )
 

--- a/mats_schedule/handlers/mats_schedule.py
+++ b/mats_schedule/handlers/mats_schedule.py
@@ -23,7 +23,7 @@ ScheduleSchema = {
     "version": pa.int64(),
     "standard_altitude": pa.int64(),
     "yaw_correction": pa.bool_(),
-    "pointing_altitudes": pa.string(),
+    "pointing_altitudes": pa.list_(pa.int64()),
     "xml_file": pa.string(),
     "description_short": pa.string(),
     "description_long": pa.string(),


### PR DESCRIPTION
Change to use list type for pointing altitudes.

Should not be deployed until Level1A is ready, see https://github.com/innosat-mats/level1a/pull/67.

Resolves #3 