### PR TITLE
Add pandas as requirement

### DIFF
--- a/mats_schedule/requirements.txt
+++ b/mats_schedule/requirements.txt
@@ -1,2 +1,2 @@
-numpy==1.23.4
 pyarrow==10.0.0
+pandas==2.0.3

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,6 @@ aws-cdk.aws-lambda-python-alpha
 boto3
 constructs
 pyarrow
-numpy
 types-boto3
 types-botocore
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,8 +46,10 @@ jsii==1.71.0
     #   constructs
 numpy==1.23.4
     # via
-    #   -r requirements.in
+    #   pandas
     #   pyarrow
+pandas==2.0.3
+    # via -r requirements.in
 publication==0.0.3
     # via
     #   aws-cdk-aws-lambda-python-alpha
@@ -60,6 +62,9 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   jsii
+    #   pandas
+pytz==2023.3
+    # via pandas
 s3transfer==0.6.0
     # via boto3
 six==1.16.0
@@ -82,5 +87,7 @@ typing-extensions==4.4.0
     # via
     #   boto3-stubs
     #   jsii
+tzdata==2023.3
+    # via pandas
 urllib3==1.26.12
     # via botocore


### PR DESCRIPTION
Missed adding pandas as requirement in lambda. Removed numpy as requirement since that is not explicitly used, but it is a requirement to pandas, so it should be ok.